### PR TITLE
Multi lock

### DIFF
--- a/c_src/sema_nif.cpp
+++ b/c_src/sema_nif.cpp
@@ -12,9 +12,7 @@ static ErlNifResourceType* SEMA;
 
 static ERL_NIF_TERM atom_ok;
 static ERL_NIF_TERM atom_error;
-static ERL_NIF_TERM atom_true;
 static ERL_NIF_TERM atom_backlog_full;
-static ERL_NIF_TERM atom_duplicate_pid;
 static ERL_NIF_TERM atom_not_found;
 static ERL_NIF_TERM atom_dead;
 static ERL_NIF_TERM atom_cnt;
@@ -237,9 +235,7 @@ static int load(ErlNifEnv *env, void **priv_data, ERL_NIF_TERM load_info) {
     if (!open_resource(env)) return -1;
     atom_ok = mk_atom(env, "ok");
     atom_error = mk_atom(env, "error");
-    atom_true = mk_atom(env, "true");
     atom_backlog_full = mk_atom(env, "backlog_full");
-    atom_duplicate_pid = mk_atom(env, "duplicate_pid");
     atom_not_found = mk_atom(env, "not_found");
     atom_dead = mk_atom(env, "dead");
     atom_cnt = mk_atom(env, "cnt");

--- a/c_src/sema_nif.cpp
+++ b/c_src/sema_nif.cpp
@@ -75,11 +75,12 @@ struct sema {
     std::atomic_uint dead_counter;
     unsigned max;
 
+    typedef std::pair<ErlNifMonitor, unsigned> mon_cnt_t;
     std::map<
         ErlNifPid,
-        ErlNifMonitor,
+        mon_cnt_t,
         std::less<ErlNifPid>,
-        enif_allocator<std::pair<const ErlNifPid, ErlNifMonitor>>
+        enif_allocator<std::pair<const ErlNifPid, mon_cnt_t>>
     > pids;
     std::mutex pid_mutex;
 
@@ -100,7 +101,7 @@ struct sema {
         return map_ret;
     }
 
-    ERL_NIF_TERM try_to_take(ErlNifEnv *env, const ErlNifPid& pid, bool mon) {
+    ERL_NIF_TERM try_to_take(ErlNifEnv *env, const ErlNifPid& pid) {
         unsigned x;
         while ((x = cnt.load(std::memory_order_acquire)) < max) {
             if (cnt.compare_exchange_strong(
@@ -109,18 +110,11 @@ struct sema {
                 std::memory_order_release,
                 std::memory_order_relaxed
             )) {
-                ErlNifMonitor proc_mon = null_mon;
-                if (!mon || monitor_pid(env, pid, proc_mon)) {
-                    if (add_pid(pid, proc_mon)) {
-                        // process added to the registry, return new count
-                        return unsigned_result(env, x + 1);
-                    } else {
-                        // process already registered, roll back
-                        cnt.fetch_sub(1, std::memory_order_acq_rel);
-                        return error_tuple(env, atom_duplicate_pid);
-                    }
+                if (maybe_monitor(env, pid)) {
+                    // process added to the registry, return new count
+                    return unsigned_result(env, x + 1);
                 } else {
-                    // process we're trying to monitor already died
+                    // process we're trying to monitor is already died
                     return error_tuple(env, atom_not_found);
                 }
             } else {
@@ -132,39 +126,58 @@ struct sema {
         return error_tuple(env, atom_backlog_full);
     }
 
+    bool maybe_monitor(ErlNifEnv *env, const ErlNifPid& pid) {
+        // activate mutex guard
+        const std::lock_guard<std::mutex> lock(pid_mutex);
+
+        // check if the pid exists in our table
+        auto it = pids.find(pid);
+        if (it == pids.end()) {
+            // process not yet registered, monitor it
+            ErlNifMonitor mon = null_mon;
+            if (monitor_pid(env, pid, mon)) {
+                pids.emplace(
+                    std::piecewise_construct,
+                    std::forward_as_tuple(pid),
+                    std::forward_as_tuple(mon, 1)
+                );
+                return true;
+            } else {
+                // process already gone
+                return false;
+            }
+        } else {
+            it->second.second++;
+            return true;
+        }
+    }
+
     bool monitor_pid(ErlNifEnv *env, const ErlNifPid& pid, ErlNifMonitor& mon) {
         return 0 == enif_monitor_process(env, this, &pid, &mon);
     }
 
-    bool add_pid(const ErlNifPid& pid, const ErlNifMonitor& mon) {
-        // activate mutex guard
-        const std::lock_guard<std::mutex> lock(pid_mutex);
-
-        // register pid
-        return pids.emplace(pid, mon).second;
-    }
-
     // unregister presumably "live" process, optionally demonitor it
-    bool del_pid(ErlNifEnv *env, const ErlNifPid& pid) {
+    unsigned del_pid(ErlNifEnv *env, const ErlNifPid& pid) {
         // activate mutex guard
         const std::lock_guard<std::mutex> lock(pid_mutex);
 
         // check if the pid exists in our table
         auto it = pids.find(pid);
         if (it == pids.end())
-            return false;
+            return 0;
 
         // optionally demonitor the process
-        auto proc_mon = it->second;
+        auto proc_mon = it->second.first;
         if (enif_compare_monitors(&proc_mon, &null_mon) != 0)
             enif_demonitor_process(env, this, &proc_mon);
 
         // deregister pid by removing from the pids table
+        unsigned ret = it->second.second;
         pids.erase(it);
-        return true;
+        return ret;
     }
 
-    // unregister (garbage-collect) "dead" procees
+    // unregister (garbage-collect) "dead" process
     void gc_pid(const ErlNifPid& pid) {
         // release resource unit
         cnt.fetch_sub(1, std::memory_order_acquire);
@@ -178,10 +191,11 @@ struct sema {
     }
 
     ERL_NIF_TERM vacate(ErlNifEnv *env, const ErlNifPid& pid) {
-        if (del_pid(env, pid)) {
+        unsigned n = del_pid(env, pid);
+        if (n > 0) {
             // process removed from registry, decrement and return new count
             return unsigned_result(env,
-                cnt.fetch_sub(1, std::memory_order_acq_rel) - 1);
+                cnt.fetch_sub(n, std::memory_order_acq_rel) - n);
         } else {
             // process not found in the registry
             return error_tuple(env, atom_not_found);
@@ -271,7 +285,7 @@ info(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
 
 static ERL_NIF_TERM
 occupy(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
-    if (argc < 1 || argc > 3)
+    if (argc != 1)
         return enif_make_badarg(env);
 
     sema *res = nullptr;
@@ -282,31 +296,16 @@ occupy(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
         return enif_make_badarg(env);
 
     ErlNifPid pid = {};
-    bool monitor = false;
 
-    if (argc > 1) {
-        if (!enif_is_pid(env, argv[1]))
-            return enif_make_badarg(env);
-        if (!enif_get_local_pid(env, argv[1], &pid))
-            return enif_make_badarg(env);
-    } else {
-        if (nullptr == enif_self(env, &pid))
-            return enif_make_badarg(env);
-        monitor = true;
-    }
+    if (nullptr == enif_self(env, &pid))
+        return enif_make_badarg(env);
 
-    if (argc > 2) {
-        if (!enif_is_atom(env, argv[2]))
-            return enif_make_badarg(env);
-        monitor = 0 == enif_compare(atom_true, argv[2]);
-    }
-
-    return res->try_to_take(env, pid, monitor);
+    return res->try_to_take(env, pid);
 }
 
 static ERL_NIF_TERM
 vacate(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
-    if (argc < 1 || argc > 2)
+    if (argc != 1)
         return enif_make_badarg(env);
 
     sema *res = nullptr;
@@ -317,15 +316,8 @@ vacate(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]) {
         return enif_make_badarg(env);
 
     ErlNifPid pid = {};
-    if (argc > 1) {
-        if (!enif_is_pid(env, argv[1]))
-            return enif_make_badarg(env);
-        if (!enif_get_local_pid(env, argv[1], &pid))
-            return enif_make_badarg(env);
-    } else {
-        if (nullptr == enif_self(env, &pid))
-            return enif_make_badarg(env);
-    }
+    if (nullptr == enif_self(env, &pid))
+        return enif_make_badarg(env);
 
     return res->vacate(env, pid);
 }
@@ -334,10 +326,7 @@ static ErlNifFunc nif_funcs[] = {
     {"create", 1, create},
     {"info", 1, info},
     {"occupy", 1, occupy},
-    {"occupy", 2, occupy},
-    {"occupy", 3, occupy},
-    {"vacate", 1, vacate},
-    {"vacate", 2, vacate}
+    {"vacate", 1, vacate}
 };
 
 ERL_NIF_INIT(sema_nif, nif_funcs, &load, nullptr, nullptr, nullptr);

--- a/src/sema_nif.erl
+++ b/src/sema_nif.erl
@@ -4,20 +4,14 @@
     create/1,
     info/1,
     occupy/1,
-    occupy/2,
-    occupy/3,
-    vacate/1,
-    vacate/2
+    vacate/1
 ]).
 
 -nifs([
     create/1,
     info/1,
     occupy/1,
-    occupy/2,
-    occupy/3,
-    vacate/1,
-    vacate/2
+    vacate/1
 ]).
 
 -on_load(init/0).
@@ -46,25 +40,12 @@ info(_) -> not_loaded(?LINE).
 -type occupy_ret() ::
     % process got resource unit, return number of units acquired so far
     {ok, N :: pos_integer()}
-    % process already acquired the resource
-    | {error, duplicate_pid}
-    % process already died
-    | {error, not_found}
     % no resource units available
     | {error, backlog_full}.
 
 % acquire resource unit for calling process, monitor process
 -spec occupy(Semaphore :: sema_ref()) -> Ret :: occupy_ret().
 occupy(_) -> not_loaded(?LINE).
-
-% acquire resource unit for process Pid, don't monitor process
--spec occupy(Semaphore :: sema_ref(), Pid :: pid()) -> Ret :: occupy_ret().
-occupy(_, _) -> not_loaded(?LINE).
-
-% acquire resource unit for process Pid, optionally monitor process
--spec occupy(Semaphore :: sema_ref(), Pid :: pid(), Monitor :: boolean()) ->
-    Ret :: occupy_ret().
-occupy(_, _, _) -> not_loaded(?LINE).
 
 -type vacate_ret() ::
     % process freed resource unit, return number of units acquired after that
@@ -75,10 +56,6 @@ occupy(_, _, _) -> not_loaded(?LINE).
 % release resource unit acquired by calling process
 -spec vacate(Semaphore :: sema_ref()) -> Ret :: vacate_ret().
 vacate(_) -> not_loaded(?LINE).
-
-% release resource unit acquired by given process
--spec vacate(Semaphore :: sema_ref(), Pid :: pid()) -> Ret :: vacate_ret().
-vacate(_, _) -> not_loaded(?LINE).
 
 % internal
 init() ->

--- a/test/sema_tests.erl
+++ b/test/sema_tests.erl
@@ -8,26 +8,22 @@ basic_api_test() ->
     S = sema_nif:create(3),
     ?assertEqual(#{cnt => 0, dead => 0, max => 3}, sema_nif:info(S)),
 
-    Pid = self(),
-    ?assertEqual({ok, 1}, sema_nif:occupy(S, Pid)),
+    ?assertEqual({ok, 1}, sema_nif:occupy(S)),
     ?assertEqual(#{cnt => 1, dead => 0, max => 3}, sema_nif:info(S)),
 
-    ?assertEqual({error, duplicate_pid}, sema_nif:occupy(S, Pid)),
-    ?assertEqual(#{cnt => 1, dead => 0, max => 3}, sema_nif:info(S)),
+    ?assertEqual({ok, 2}, sema_nif:occupy(S)),
+    ?assertEqual(#{cnt => 2, dead => 0, max => 3}, sema_nif:info(S)),
 
-    ?assertEqual({ok, 0}, sema_nif:vacate(S, Pid)),
+    ?assertEqual({ok, 3}, sema_nif:occupy(S)),
+    ?assertEqual(#{cnt => 3, dead => 0, max => 3}, sema_nif:info(S)),
+
+    ?assertEqual({error, backlog_full}, sema_nif:occupy(S)),
+    ?assertEqual(#{cnt => 3, dead => 0, max => 3}, sema_nif:info(S)),
+
+    ?assertEqual({ok, 0}, sema_nif:vacate(S)),
     ?assertEqual(#{cnt => 0, dead => 0, max => 3}, sema_nif:info(S)),
 
-    ?assertEqual({error, not_found}, sema_nif:vacate(S, Pid)),
-    ?assertEqual(#{cnt => 0, dead => 0, max => 3}, sema_nif:info(S)),
-
-    ?assertEqual({ok, 1}, sema_nif:occupy(S, Pid)),
-    ?assertEqual(#{cnt => 1, dead => 0, max => 3}, sema_nif:info(S)),
-
-    ?assertEqual({error, duplicate_pid}, sema_nif:occupy(S, Pid)),
-    ?assertEqual(#{cnt => 1, dead => 0, max => 3}, sema_nif:info(S)),
-
-    ?assertEqual({ok, 0}, sema_nif:vacate(S, Pid)),
+    ?assertEqual({error, not_found}, sema_nif:vacate(S)),
     ?assertEqual(#{cnt => 0, dead => 0, max => 3}, sema_nif:info(S)),
 
     ?assertEqual({ok, 1}, sema_nif:occupy(S)),
@@ -55,12 +51,12 @@ test_parallel(BacklogSize, ProcessCount) ->
     Top = self(),
     F = fun() ->
         Pid = self(),
-        case sema_nif:occupy(S, Pid) of
+        case sema_nif:occupy(S) of
             {ok, N} when is_integer(N), N > 0, N =< BacklogSize ->
                 Top ! {tenant, Pid, N},
                 receive
                     leave ->
-                        {ok, Left} = sema_nif:vacate(S, Pid),
+                        {ok, Left} = sema_nif:vacate(S),
                         Top ! {left, Pid, Left}
                 end;
             {error, backlog_full} ->
@@ -122,73 +118,44 @@ atomic_ops(N) ->
 sema_race_test_() -> {timeout, 60, fun test_sema_race/0}.
 
 test_sema_race() ->
-    ?assertNotException(
-        throw,
-        {error, incomplete},
-        race_loop(4000, 1000000, fun sema_ops/1)
-    ).
+    race_loop(4_000, 1_000_000, fun sema_ops/1).
 
 sema_ops(N) ->
     S = sema_nif:create(2),
-    Pid = spawn(fun() -> sema_nif:occupy(S, self()) end),
+    {Pid, Mref} = spawn_monitor(fun() ->
+        sema_nif:occupy(S),
+        receive
+            x -> x
+        end
+    end),
     spin(N),
     exit(Pid, kill),
-    _ = sema_nif:info(S),
-    case sema_nif:occupy(S, Pid) of
-        {error, duplicate_pid} ->
-            % occupation by Pid is done in full, reduce kill delay
-            true;
+    case sema_nif:occupy(S) of
+        % early kill
         {ok, 1} ->
             % occupation by Pid is not done, increase kill delay
             false;
+        % late kill - S is fully occupied, will have to reduce delay
         {ok, 2} ->
-            % this may happen due to race, double check it after a delay
-            timer:sleep(1),
-            % receive {'DOWN', Mref, process, Pid, _Info} -> ok end,
-            case sema_nif:vacate(S, Pid) of
-                {ok, 0} ->
-                    true;
-                {ok, 1} ->
-                    % occupation was partally done, Pid was not registered!
-                    throw({error, incomplete});
-                Else ->
-                    throw({error, Else})
-            end
+            % ensure process died
+            receive
+                {'DOWN', Mref, process, Pid, _Info} -> ok
+            end,
+            % ensure nif handled monitor
+            ok = wait_dead(1_000, S),
+            % ensure only one unit occupied now
+            {ok, 0} = sema_nif:vacate(S),
+            true
     end.
 
-sema_gc_race_test_() -> {timeout, 60, fun test_sema_gc_race/0}.
-
-test_sema_gc_race() ->
-    race_loop(4_000, 1_000_000, fun sema_ops_gc/1).
-
-% version with automatic dead processes collection
-sema_ops_gc(N) ->
-    S = sema_nif:create(1),
-    % acquire and monitor
-    Pid = spawn(fun() -> sema_nif:occupy(S) end),
-    spin(N),
-    exit(Pid, kill),
-    wait_loop(S, 10, 100_000).
-
-wait_loop(_, _, 0) ->
-    % occupation was partally done, Pid was not registered!
-    throw({error, incomplete});
-wait_loop(_, 0, _) ->
-    % occupation by Pid is not done, increase kill delay
-    false;
-wait_loop(S, N1, N2) ->
+wait_dead(0, _) ->
+    alive;
+wait_dead(N, S) ->
     case sema_nif:info(S) of
-        #{cnt := 0, dead := 0} ->
-            % occupation by Pid is not yet done, or, it's done, but
-            % dead counter it not yet updated, try couple more times
-            wait_loop(S, N1 - 1, N2);
-        #{cnt := 0, dead := 1} ->
-            % acquire/release is done in full, reduce kill delay
-            true;
-        #{cnt := 1, dead := 0} ->
-            % occupation is partally done, Pid is not yet registered
-            % keep checking it again until success or timeout
-            wait_loop(S, N1, N2 - 1)
+        #{dead := 1} ->
+            ok;
+        _ ->
+            wait_dead(N - 1, S)
     end.
 
 race_loop(SpinCount, IterationsLeft, Fun) ->

--- a/test/sema_tests.erl
+++ b/test/sema_tests.erl
@@ -142,7 +142,7 @@ sema_ops(N) ->
                 {'DOWN', Mref, process, Pid, _Info} -> ok
             end,
             % ensure nif handled monitor
-            ok = wait_dead(1_000, S),
+            ok = wait_dead(1_000_000, S),
             % ensure only one unit occupied now
             {ok, 0} = sema_nif:vacate(S),
             true


### PR DESCRIPTION
This PR removes the single-lock-per-process restriction.
Also, it removes the PID argument from the API calls, since there should not be a point to acquire a lock on behalf of the "other" process (no consistency guarantee could be provided in this case).